### PR TITLE
Add source code and build script for the cpu frequency getter

### DIFF
--- a/go/cpufreqgetter/Dockerfile
+++ b/go/cpufreqgetter/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang
+COPY getcpufreq.go .
+RUN go build getcpufreq.go
+
+FROM scratch
+COPY --from=0 /go/getcpufreq .
+CMD ["./getcpufreq"]

--- a/go/cpufreqgetter/README.md
+++ b/go/cpufreqgetter/README.md
@@ -1,0 +1,6 @@
+# cpufreqgetter
+Golang code to build minimal images to get CPU frequency by reading the file /proc/cpuinfo and parsing it to the float value
+
+**build multi-arch images**
+
+./buidx.sh

--- a/go/cpufreqgetter/buildx.sh
+++ b/go/cpufreqgetter/buildx.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+set -x
+REPO_NAME=icr.io/cpopen/turbonomic
+IMAGE_NAME=cpufreqgetter
+PLATFORM_OS_ARCH_LIST="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
+docker buildx build --platform $PLATFORM_OS_ARCH_LIST --label "git-version=latest" --push -t $REPO_NAME/$IMAGE_NAME:latest .

--- a/go/cpufreqgetter/getcpufreq.go
+++ b/go/cpufreqgetter/getcpufreq.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+var (
+	supportedOSArch = map[string]bool{
+		"linux.amd64":   true,
+		"linux.ppc64le": true,
+		"linux.s390x":   true,
+	}
+)
+
+func main() {
+	hostName, _ := os.Hostname()
+	osArch := runtime.GOOS + "." + runtime.GOARCH
+	if _, ok := supportedOSArch[osArch]; !ok {
+		fmt.Printf("The OSArch[%v] on the node[%v] is not supported!", osArch, hostName)
+		return
+	}
+
+	cpuinfo, err := os.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		fmt.Printf("Can't open the cpu proc file on the node[%v]:%v", hostName, err)
+	}
+
+	switch osArch {
+	case "linux.amd64", "linux.s390x":
+		re, err := regexp.Compile(`cpu MHz.*`)
+		if err != nil {
+			fmt.Printf("Can't parse regular expression for the node[%v]: %v", hostName, err)
+			return
+		}
+		cpufreq := re.FindString(string(cpuinfo))
+		str := strings.Split(cpufreq, ":")
+		if len(str) != 2 {
+			fmt.Printf("Get an invalid cpu frequency string[%v] for the node[%v]", cpufreq, hostName)
+			return
+		}
+		fmt.Printf(strings.TrimSpace(str[1]))
+	case "linux.ppc64le":
+		re, err := regexp.Compile(`clock.*`)
+		if err != nil {
+			fmt.Printf("Can't parse regular expression for the node[%v]: %v", hostName, err)
+			return
+		}
+		cpufreq := re.FindString(string(cpuinfo))
+		str := strings.Split(cpufreq, ":")
+		if len(str) != 2 {
+			fmt.Printf("Get an invalid cpu frequency string[%v] for the node[%v]", cpufreq, hostName)
+			return
+		}
+		clock := strings.TrimSpace(str[1])
+		// TODO: I cannot find the specification of /proc/cpuinfo output for Power linux. It is not clear if the MHz unit
+		//   could potentially be different, such as GHz, on different node. For now, assume the unit is always MHz
+		fmt.Printf(strings.TrimSuffix(clock, "MHz"))
+	}
+
+}


### PR DESCRIPTION
Have built multi-arches images and verified them on ppc64/amd64/s390x

## X86
```
[root@api.ocp410kev.cp.fyre.ibm.com git]# uname -m
x86_64
[root@api.ocp410kev.cp.fyre.ibm.com git]# docker run kevin0204/cpufreqgetter
2000.000
```

## Power
```
[root@stressed1 ~]# uname -m
ppc64le
[root@stressed1 ~]# docker run docker.io/kevin0204/cpufreqgetter
Unable to find image 'kevin0204/cpufreqgetter:latest' locally
latest: Pulling from kevin0204/cpufreqgetter
740e728efd56: Pull complete 
Digest: sha256:62b901ad6fe1836a0c3a3ac288c30e4d13c5e60e273c3aba0c646964c9ff647d
Status: Downloaded newer image for kevin0204/cpufreqgetter:latest
2893.000000
```

## Z
```
[root@synoptic1 ~]# uname -m
s390x
[root@synoptic1 ~]# docker run docker.io/kevin0204/cpufreqgetter
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
Trying to pull docker.io/kevin0204/cpufreqgetter:latest...
Getting image source signatures
Copying blob 6122b798a4d6 done  
Copying config b520304453 done  
Writing manifest to image destination
Storing signatures
5208
```
