### PR TITLE
[OM-95962]:Fix security vulnerability issue

### DIFF
--- a/go/cpufreqgetter/Dockerfile
+++ b/go/cpufreqgetter/Dockerfile
@@ -4,4 +4,9 @@ RUN go build getcpufreq.go
 
 FROM scratch
 COPY --from=0 /go/getcpufreq .
+### Containers should NOT run as root as a good practice
+### Refer to the following for more details
+### https://docs.docker.com/engine/security/#linux-kernel-capabilities
+### https://docs.bitnami.com/tutorials/why-non-root-containers-are-important-for-security
+USER 10001
 CMD ["./getcpufreq"]


### PR DESCRIPTION
### Background:
```
./tt images pull-and-scan --user username:password --url "https://xxx" --control-group public icr.io/cpopen/turbonomic/cpufreqgetter:1.0.0
```
Scan the image and get an `H` security vulnerability issue:
```
It is a good practice to run the container as a non-root user, if possible. Though user namespace mapping is now available, if a user is already defined in the container image, the container is run as that user by default, and specific user namespace remapping is not required
```
Running containers as a non-root user substantially decreases the risk that container -> host privilege escalation could occur. This is an added security benefit. ([Docker docs](https://docs.docker.com/engine/security/#linux-kernel-capabilities), [Bitnami blog post](https://engineering.bitnami.com/articles/why-non-root-containers-are-important-for-security.html))